### PR TITLE
Fix Book form not validating on field updates

### DIFF
--- a/lib/terrible_web/live/book_live/form_component.ex
+++ b/lib/terrible_web/live/book_live/form_component.ex
@@ -57,7 +57,7 @@ defmodule TerribleWeb.BookLive.FormComponent do
 
   @impl true
   def handle_event("validate", %{"book" => book_params}, socket) do
-    {:noreply, assign(socket, :from, AshPhoenix.Form.validate(socket.assigns.form, book_params))}
+    {:noreply, assign(socket, :form, AshPhoenix.Form.validate(socket.assigns.form, book_params))}
   end
 
   def handle_event("save", %{"book" => book_params}, socket) do

--- a/test/terrible_web/live/book_live_test.exs
+++ b/test/terrible_web/live/book_live_test.exs
@@ -49,6 +49,10 @@ defmodule TerribleWeb.BookLiveTest do
 
       assert index_live
              |> form("#book-form", book: @invalid_attrs)
+             |> render_change() =~ "is required"
+
+      assert index_live
+             |> form("#book-form", book: @invalid_attrs)
              |> render_submit() =~ "is required"
     end
 
@@ -78,6 +82,10 @@ defmodule TerribleWeb.BookLiveTest do
 
       assert index_live |> element("#books-#{book.id} a", "Edit") |> render_click() =~
                "Edit Book"
+
+      assert index_live
+             |> form("#book-form", book: @invalid_attrs)
+             |> render_change() =~ "is required"
 
       assert index_live
              |> form("#book-form", book: @invalid_attrs)
@@ -125,6 +133,10 @@ defmodule TerribleWeb.BookLiveTest do
 
       assert show_live |> element("a", "Edit") |> render_click() =~
                "Edit Book"
+
+      assert show_live
+             |> form("#book-form", book: @invalid_attrs)
+             |> render_change() =~ "is required"
 
       assert show_live
              |> form("#book-form", book: @invalid_attrs)


### PR DESCRIPTION
There is a typo that prevented the Book form_component's validate method to not update the form object everytime it is invoked. This fixes that.