### PR TITLE
Add manipulation of Envelopes in Budget Show page

### DIFF
--- a/lib/terrible/budgeting/flows/create_envelope.ex
+++ b/lib/terrible/budgeting/flows/create_envelope.ex
@@ -1,0 +1,49 @@
+defmodule Terrible.Budgeting.CreateEnvelope do
+  @moduledoc """
+  A flow module for creating a new Envelope and MonthlyEnvelope records
+  for all the Budget records that exist for the associated Book.
+  """
+
+  use Ash.Flow, otp_app: :terrible
+
+  alias Terrible.Budgeting.{Category, Envelope}
+  alias Terrible.Budgeting.CreateEnvelope.CreateMonthlyEnvelopes
+
+  flow do
+    api Terrible.Budgeting
+
+    description "A flow module for creating a new Envelope and MonthlyEnvelope records for all the Budget records that exist for the associated Book"
+
+    argument :name, :string do
+      allow_nil? false
+    end
+
+    argument :category_id, :uuid do
+      allow_nil? false
+    end
+
+    returns :create_envelope
+  end
+
+  steps do
+    read :get_category, Category, :by_id do
+      input %{
+        id: arg(:category_id)
+      }
+    end
+
+    create :create_envelope, Envelope, :create do
+      input %{
+        name: arg(:name),
+        category_id: arg(:category_id)
+      }
+    end
+
+    custom :create_monthly_envelopes, CreateMonthlyEnvelopes do
+      input %{
+        category: result(:get_category),
+        envelope: result(:create_envelope)
+      }
+    end
+  end
+end

--- a/lib/terrible/budgeting/flows/create_envelope/create_monthly_envelopes.ex
+++ b/lib/terrible/budgeting/flows/create_envelope/create_monthly_envelopes.ex
@@ -1,0 +1,28 @@
+defmodule Terrible.Budgeting.CreateEnvelope.CreateMonthlyEnvelopes do
+  @moduledoc """
+  Creates MonthlyEnvelope records to backfill all of the Budget records that are
+  associated with the Book in which the given Category record belongs to.
+  """
+
+  use Ash.Flow.Step
+
+  alias Terrible.Budgeting.{Budget, MonthlyEnvelope}
+
+  def run(input, _opts, _context) do
+    category = input[:category]
+    envelope = input[:envelope]
+
+    monthly_envelopes =
+      category
+      |> Map.get(:book_id)
+      |> Budget.list_by_book_id!()
+      |> Enum.map(fn budget ->
+        MonthlyEnvelope.create!(%{
+          budget_id: budget.id,
+          envelope_id: envelope.id
+        })
+      end)
+
+    {:ok, monthly_envelopes}
+  end
+end

--- a/lib/terrible/budgeting/flows/destroy_envelope.ex
+++ b/lib/terrible/budgeting/flows/destroy_envelope.ex
@@ -1,0 +1,43 @@
+defmodule Terrible.Budgeting.DestroyEnvelope do
+  @moduledoc """
+  A flow module for deleting an Envelope and all the MonthlyEnvelope
+  records associated with it.
+  """
+
+  use Ash.Flow, otp_app: :terrible
+
+  alias Terrible.Budgeting.Envelope
+  alias Terrible.Budgeting.DestroyEnvelope.{BroadcastDestroyEvent, DestroyMonthlyEnvelopes}
+
+  flow do
+    api Terrible.Budgeting
+
+    description "A flow module for deleting an Envelope and all the MonthlyEnvelope records associated with it."
+
+    argument :id, :uuid do
+      allow_nil? false
+    end
+
+    returns :get_envelope
+  end
+
+  steps do
+    read :get_envelope, Envelope, :by_id do
+      input %{
+        id: arg(:id)
+      }
+    end
+
+    custom :destroy_monthly_envelopes, DestroyMonthlyEnvelopes do
+      input result(:get_envelope)
+    end
+
+    destroy :destroy_envelope, Envelope, :destroy do
+      record result(:destroy_monthly_envelopes)
+    end
+
+    custom :broadcast_destroy_event, BroadcastDestroyEvent do
+      input result(:destroy_envelope)
+    end
+  end
+end

--- a/lib/terrible/budgeting/flows/destroy_envelope/broadcast_destroy_event.ex
+++ b/lib/terrible/budgeting/flows/destroy_envelope/broadcast_destroy_event.ex
@@ -1,0 +1,18 @@
+defmodule Terrible.Budgeting.DestroyEnvelope.BroadcastDestroyEvent do
+  @moduledoc """
+  Broadcasts the DestroyEnvelope event to Phoenix PubSub.
+  """
+
+  use Ash.Flow.Step
+
+  alias Terrible.Budgeting.Category
+
+  def run(envelope, _opts, _context) do
+    category = Category.get_by_id!(envelope.category_id)
+
+    message = {:destroyed_envelope, %{id: envelope.id, category_id: category.id}}
+    Phoenix.PubSub.broadcast(Terrible.PubSub, "book:" <> category.book_id, message)
+
+    {:ok, envelope}
+  end
+end

--- a/lib/terrible/budgeting/flows/destroy_envelope/destroy_monthly_envelopes.ex
+++ b/lib/terrible/budgeting/flows/destroy_envelope/destroy_monthly_envelopes.ex
@@ -1,0 +1,21 @@
+defmodule Terrible.Budgeting.DestroyEnvelope.DestroyMonthlyEnvelopes do
+  @moduledoc """
+  Deletes all MonthlyEnvelope records associated with the given Envelope
+  to ensure that no record gets orphaned before deleting the Envelope.
+  """
+
+  use Ash.Flow.Step
+
+  import Ecto.Query
+
+  alias Terrible.Budgeting.MonthlyEnvelope
+  alias Terrible.Repo
+
+  def run(envelope, _opts, _context) do
+    MonthlyEnvelope
+    |> where([me], me.envelope_id == ^envelope.id)
+    |> Repo.delete_all()
+
+    {:ok, envelope}
+  end
+end

--- a/lib/terrible/budgeting/resources/budget.ex
+++ b/lib/terrible/budgeting/resources/budget.ex
@@ -29,6 +29,20 @@ defmodule Terrible.Budgeting.Budget do
   actions do
     defaults [:read, :create, :update, :destroy]
 
+    read :by_id do
+      argument :id, :uuid, allow_nil?: false
+
+      get? true
+
+      filter expr(id == ^arg(:id))
+    end
+
+    read :by_book_id do
+      argument :book_id, :uuid, allow_nil?: false
+
+      filter expr(book_id == ^arg(:book_id))
+    end
+
     read :get_by_book_id_and_name do
       argument :id, :uuid, allow_nil?: false
       argument :name, :string, allow_nil?: false
@@ -45,7 +59,9 @@ defmodule Terrible.Budgeting.Budget do
     define :read_all, action: :read
     define :update, action: :update
     define :destroy, action: :destroy
+    define :list_by_book_id, args: [:book_id], action: :by_book_id
     define :get_by_book_id_and_name, args: [:id, :name], action: :get_by_book_id_and_name
+    define :get_by_id, args: [:id], action: :by_id
   end
 
   relationships do

--- a/lib/terrible/budgeting/resources/envelope.ex
+++ b/lib/terrible/budgeting/resources/envelope.ex
@@ -31,10 +31,16 @@ defmodule Terrible.Budgeting.Envelope do
   actions do
     defaults [:read, :create, :update, :destroy]
 
-    read :by_category_id do
+    read :by_id do
       argument :id, :uuid, allow_nil?: false
 
       get? true
+
+      filter expr(id == ^arg(:id))
+    end
+
+    read :by_category_id do
+      argument :category_id, :uuid, allow_nil?: false
 
       filter expr(category_id == ^arg(:id))
     end
@@ -46,7 +52,8 @@ defmodule Terrible.Budgeting.Envelope do
     define :read_all, action: :read
     define :update, action: :update
     define :destroy, action: :destroy
-    define :list_by_category_id, args: [:id], action: :by_category_id
+    define :list_by_category_id, args: [:category_id], action: :by_category_id
+    define :get_by_id, args: [:id], action: :by_id
   end
 
   relationships do

--- a/lib/terrible_web/live/budget_live/category_component.ex
+++ b/lib/terrible_web/live/budget_live/category_component.ex
@@ -23,6 +23,7 @@ defmodule TerribleWeb.BudgetLive.CategoryComponent do
             <%= unless @envelopes && Enum.any?(@envelopes) do %>
               <span>
                 <.link
+                  class="delete-category"
                   phx-click={JS.push("delete_category", value: %{id: @category.id})}
                   data-confirm="Are you sure?"
                 >
@@ -30,6 +31,13 @@ defmodule TerribleWeb.BudgetLive.CategoryComponent do
                 </.link>
               </span>
             <% end %>
+            <span>
+              <.link patch={
+                ~p"/books/#{@book}/budgets/#{@budget.name}/categories/#{@category}/envelopes/new"
+              }>
+                New Envelope
+              </.link>
+            </span>
           </th>
         </tr>
       </thead>
@@ -39,6 +47,7 @@ defmodule TerribleWeb.BudgetLive.CategoryComponent do
             <.live_component
               module={TerribleWeb.BudgetLive.MonthlyEnvelopeComponent}
               id={envelope.id}
+              book={@book}
               budget={@budget}
               category={@category}
               envelope={envelope}

--- a/lib/terrible_web/live/budget_live/envelope_form_component.ex
+++ b/lib/terrible_web/live/budget_live/envelope_form_component.ex
@@ -1,0 +1,103 @@
+defmodule TerribleWeb.BudgetLive.EnvelopeFormComponent do
+  use TerribleWeb, :live_component
+
+  alias Terrible.Budgeting
+  alias Terrible.Budgeting.CreateEnvelope
+  alias Terrible.Budgeting.Envelope
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.header>
+        <%= @title %>
+      </.header>
+
+      <.simple_form
+        :let={f}
+        for={@form}
+        id="envelope-form"
+        phx-target={@myself}
+        phx-change="validate"
+        phx-submit="save"
+      >
+        <.input field={{f, :name}} type="text" label="Name" />
+        <.input field={{f, :category_id}} type="hidden" />
+        <:actions>
+          <.button phx-disable-with="Saving...">Save Envelope</.button>
+        </:actions>
+      </.simple_form>
+    </div>
+    """
+  end
+
+  @impl true
+  def update(%{category: category, envelope: envelope} = assigns, socket) do
+    form =
+      if envelope.id do
+        AshPhoenix.Form.for_action(
+          envelope,
+          :update,
+          as: "envelope",
+          api: Budgeting
+        )
+      else
+        AshPhoenix.Form.for_action(
+          Envelope,
+          :create,
+          as: "envelope",
+          api: Budgeting,
+          prepare_source: fn changeset ->
+            Ash.Changeset.set_argument(changeset, :category_id, category.id)
+          end
+        )
+      end
+
+    socket =
+      socket
+      |> assign(assigns)
+      |> assign(:form, form)
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_event("validate", %{"envelope" => envelope_params}, socket) do
+    {:noreply,
+     assign(socket, :form, AshPhoenix.Form.validate(socket.assigns.form, envelope_params))}
+  end
+
+  def handle_event("save", %{"envelope" => envelope_params}, socket) do
+    form = AshPhoenix.Form.validate(socket.assigns.form, envelope_params)
+
+    if form.valid? do
+      action = socket.assigns.form.type
+
+      case action do
+        :update ->
+          AshPhoenix.Form.submit(
+            socket.assigns.form,
+            params: envelope_params,
+            before_submit: fn changeset ->
+              Ash.Changeset.set_argument(changeset, :category_id, socket.assigns.category.id)
+            end
+          )
+
+        :create ->
+          CreateEnvelope.run!(
+            Map.get(envelope_params, "name"),
+            Map.get(envelope_params, "category_id")
+          )
+      end
+
+      socket =
+        socket
+        |> put_flash(:info, "Envelope #{action}d successfully")
+        |> push_navigate(to: socket.assigns.navigate)
+
+      {:noreply, socket}
+    else
+      {:noreply, assign(socket, form: form)}
+    end
+  end
+end

--- a/lib/terrible_web/live/budget_live/monthly_envelope_component.ex
+++ b/lib/terrible_web/live/budget_live/monthly_envelope_component.ex
@@ -10,8 +10,25 @@ defmodule TerribleWeb.BudgetLive.MonthlyEnvelopeComponent do
   @impl true
   def render(assigns) do
     ~H"""
-    <tr>
+    <tr id={"envelopes-#{@envelope.id}"}>
       <td><%= @envelope.name %></td>
+      <td>
+        <span>
+          <.link patch={
+            ~p"/books/#{@book}/budgets/#{@budget.name}/categories/#{@category}/envelopes/#{@envelope}/edit"
+          }>
+            Edit
+          </.link>
+        </span>
+        <span>
+          <.link
+            phx-click={JS.push("delete_envelope", value: %{id: @envelope.id})}
+            data-confirm="Are you sure?"
+          >
+            Delete
+          </.link>
+        </span>
+      </td>
       <td><%= cents_to_whole(@monthly_envelope.assigned_cents) %></td>
     </tr>
     """

--- a/lib/terrible_web/live/budget_live/show.ex
+++ b/lib/terrible_web/live/budget_live/show.ex
@@ -1,10 +1,18 @@
 defmodule TerribleWeb.BudgetLive.Show do
   use TerribleWeb, :live_view
 
-  alias Terrible.Budgeting.{Book, Budget, Category}
+  alias Terrible.Budgeting.{Book, Budget, Category, Envelope}
+  alias Terrible.Budgeting.DestroyEnvelope
+  alias TerribleWeb.BudgetLive.CategoryComponent
 
   @impl true
-  def mount(_params, _session, socket) do
+  def mount(%{"book_id" => book_id}, _session, socket) do
+    if connected?(socket) do
+      with {:ok, book} <- Book.get_by_id(book_id) do
+        Phoenix.PubSub.subscribe(Terrible.PubSub, "book:" <> book.id)
+      end
+    end
+
     {:ok, socket}
   end
 
@@ -58,6 +66,48 @@ defmodule TerribleWeb.BudgetLive.Show do
     |> assign(:category, category)
   end
 
+  defp apply_action(socket, :new_envelope, %{
+         "book_id" => book_id,
+         "name" => name,
+         "category_id" => category_id
+       }) do
+    book = Book.get_by_id!(book_id)
+    budget = Budget.get_by_book_id_and_name!(book_id, name)
+    categories = Category.list_by_book_id!(book.id)
+    category = Category.get_by_id!(category_id)
+
+    socket
+    |> assign(:page_title, "New Envelope | #{book.name}")
+    |> assign(:form_title, "Create New Envelope")
+    |> assign(:book, book)
+    |> assign(:budget, budget)
+    |> assign(:categories, categories)
+    |> assign(:category, category)
+    |> assign(:envelope, %Envelope{})
+  end
+
+  defp apply_action(socket, :edit_envelope, %{
+         "book_id" => book_id,
+         "name" => name,
+         "category_id" => category_id,
+         "envelope_id" => envelope_id
+       }) do
+    book = Book.get_by_id!(book_id)
+    budget = Budget.get_by_book_id_and_name!(book_id, name)
+    categories = Category.list_by_book_id!(book.id)
+    category = Category.get_by_id!(category_id)
+    envelope = Envelope.get_by_id!(envelope_id)
+
+    socket
+    |> assign(:page_title, "Edit Envelope | #{book.name}")
+    |> assign(:form_title, "Edit Envelope")
+    |> assign(:book, book)
+    |> assign(:budget, budget)
+    |> assign(:categories, categories)
+    |> assign(:category, category)
+    |> assign(:envelope, envelope)
+  end
+
   @impl true
   def handle_event("delete_category", %{"id" => id}, socket) do
     category = Category.get_by_id!(id)
@@ -65,5 +115,21 @@ defmodule TerribleWeb.BudgetLive.Show do
     :ok = Category.destroy(category)
 
     {:noreply, assign(socket, :categories, Category.list_by_book_id!(book_id))}
+  end
+
+  @impl true
+  def handle_event("delete_envelope", %{"id" => id}, socket) do
+    envelope = Envelope.get_by_id!(id)
+    category = Category.get_by_id!(envelope.category_id)
+    DestroyEnvelope.run!(envelope.id)
+
+    {:noreply, assign(socket, :categories, Category.list_by_book_id!(category.book_id))}
+  end
+
+  @impl true
+  def handle_info({:destroyed_envelope, payload}, socket) do
+    send_update(CategoryComponent, id: payload.category_id)
+
+    {:noreply, socket}
   end
 end

--- a/lib/terrible_web/live/budget_live/show.html.heex
+++ b/lib/terrible_web/live/budget_live/show.html.heex
@@ -34,3 +34,19 @@
     navigate={~p"/books/#{@book.id}/budgets/#{@budget.name}"}
   />
 </.modal>
+
+<.modal
+  :if={@live_action in [:new_envelope, :edit_envelope]}
+  id="envelope-modal"
+  show
+  on_cancel={JS.navigate(~p"/books/#{@book}/budgets/#{@budget.name}")}
+>
+  <.live_component
+    module={TerribleWeb.BudgetLive.EnvelopeFormComponent}
+    id={@envelope.id || :new}
+    title={@form_title}
+    category={@category}
+    envelope={@envelope}
+    navigate={~p"/books/#{@book.id}/budgets/#{@budget.name}"}
+  />
+</.modal>

--- a/lib/terrible_web/router.ex
+++ b/lib/terrible_web/router.ex
@@ -29,6 +29,14 @@ defmodule TerribleWeb.Router do
     live "/books/:book_id/budgets/:name/categories/:category_id/edit",
          BudgetLive.Show,
          :edit_category
+
+    live "/books/:book_id/budgets/:name/categories/:category_id/envelopes/new",
+         BudgetLive.Show,
+         :new_envelope
+
+    live "/books/:book_id/budgets/:name/categories/:category_id/envelopes/:envelope_id/edit",
+         BudgetLive.Show,
+         :edit_envelope
   end
 
   # Other scopes may use custom stacks.

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -28,6 +28,8 @@ defmodule TerribleWeb.ConnCase do
       import Plug.Conn
       import Phoenix.ConnTest
       import TerribleWeb.ConnCase
+
+      import Terrible.BudgetingFixtures
     end
   end
 

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -24,6 +24,8 @@ defmodule Terrible.DataCase do
       import Ecto.Changeset
       import Ecto.Query
       import Terrible.DataCase
+
+      import Terrible.BudgetingFixtures
     end
   end
 

--- a/test/terrible/budgeting/flows/create_envelope_test.exs
+++ b/test/terrible/budgeting/flows/create_envelope_test.exs
@@ -1,0 +1,49 @@
+defmodule Terrible.Budgeting.CreateEnvelopeTest do
+  use Terrible.DataCase
+
+  alias Terrible.Budgeting.CreateEnvelope
+
+  describe "run" do
+    setup [:create_essential_fixtures]
+
+    test "with valid data creates an Envelope and a MonthlyEnvelope for each Budget the given Book has",
+         %{category: category} do
+      envelope =
+        "New Category"
+        |> CreateEnvelope.run!(category.id)
+        |> Map.get(:result)
+
+      assert envelope.name == "New Category"
+      assert envelope.category_id == category.id
+    end
+
+    test "with blank data returns error" do
+      assert_raise Ash.Error.Invalid, ~r/attribute name is required/, fn ->
+        CreateEnvelope.run!(nil, nil)
+      end
+    end
+  end
+
+  defp create_essential_fixtures(_) do
+    book = book_fixture(name: "Test Book")
+
+    budget =
+      budget_fixture(%{
+        name: "202303",
+        month: ~D[2023-03-04],
+        book_id: book.id
+      })
+
+    category =
+      category_fixture(%{
+        name: "Test Category",
+        book_id: book.id
+      })
+
+    %{
+      book: book,
+      budget: budget,
+      category: category
+    }
+  end
+end

--- a/test/terrible/budgeting/flows/destroy_envelope_test.exs
+++ b/test/terrible/budgeting/flows/destroy_envelope_test.exs
@@ -1,0 +1,62 @@
+defmodule Terrible.Budgeting.DestroyEnvelopeTest do
+  use Terrible.DataCase
+
+  require Ash.Query
+
+  alias Terrible.Budgeting
+  alias Terrible.Budgeting.DestroyEnvelope
+  alias Terrible.Budgeting.MonthlyEnvelope
+
+  describe "run" do
+    setup [:create_fixtures]
+
+    test "Deletes Envelope and its associated MonthlyEnvelopes", %{envelope: envelope} do
+      initial_monthly_envelopes =
+        MonthlyEnvelope
+        |> Ash.Query.for_read(:read)
+        |> Budgeting.read!()
+
+      assert Enum.count(initial_monthly_envelopes) == 1
+
+      DestroyEnvelope.run!(envelope.id)
+
+      monthly_envelopes =
+        MonthlyEnvelope
+        |> Ash.Query.for_read(:read)
+        |> Budgeting.read!()
+
+      assert Enum.empty?(monthly_envelopes)
+    end
+  end
+
+  defp create_fixtures(_) do
+    book = book_fixture(name: "Test Book")
+
+    budget =
+      budget_fixture(%{
+        name: "202303",
+        month: ~D[2023-03-04],
+        book_id: book.id
+      })
+
+    category =
+      category_fixture(%{
+        name: "Test Category",
+        book_id: book.id
+      })
+
+    envelope =
+      envelope_fixture(%{
+        name: "Test Envelope",
+        category_id: category.id
+      })
+
+    monthly_envelope_fixture(%{
+      budget_id: budget.id,
+      envelope_id: envelope.id,
+      assigned_cents: 1234
+    })
+
+    %{envelope: envelope}
+  end
+end

--- a/test/terrible_web/live/book_live_test.exs
+++ b/test/terrible_web/live/book_live_test.exs
@@ -2,7 +2,6 @@ defmodule TerribleWeb.BookLiveTest do
   use TerribleWeb.ConnCase
 
   import Phoenix.LiveViewTest
-  import Terrible.BudgetingFixtures
 
   @create_attrs %{name: "Test Book"}
   @update_attrs %{name: "Test Book Updated"}

--- a/test/terrible_web/live/budget_live/category_test.exs
+++ b/test/terrible_web/live/budget_live/category_test.exs
@@ -1,0 +1,162 @@
+defmodule TerribleWeb.BudgetLive.CategoryTest do
+  use TerribleWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  describe "New Category" do
+    setup [:create_essential_fixtures]
+
+    test "New Category form submission with correct data creates a new Category", %{
+      conn: conn,
+      book: book,
+      budget: budget
+    } do
+      {:ok, show_live, _html} = live(conn, ~p"/books/#{book}/budgets/#{budget.name}")
+
+      assert show_live |> element("a", "New Category") |> render_click() =~ "Create New Category"
+
+      assert_patch(show_live, ~p"/books/#{book}/budgets/#{budget.name}/categories/new")
+
+      {:ok, _show_live, html} =
+        show_live
+        |> form("#category-form", category: %{name: "Test New Category"})
+        |> render_submit()
+        |> follow_redirect(conn, ~p"/books/#{book}/budgets/#{budget.name}")
+
+      assert html =~ "Category created successfully"
+      assert html =~ "Test New Category"
+    end
+
+    test "New Category form submission with blank data returns error", %{
+      conn: conn,
+      book: book,
+      budget: budget
+    } do
+      {:ok, show_live, _html} = live(conn, ~p"/books/#{book}/budgets/#{budget.name}")
+
+      assert show_live |> element("a", "New Category") |> render_click() =~ "Create New Category"
+
+      assert show_live
+             |> form("#category-form", category: %{name: ""})
+             |> render_change() =~ "is required"
+
+      assert show_live
+             |> form("#category-form", category: %{name: ""})
+             |> render_submit() =~ "is required"
+    end
+  end
+
+  describe "Edit Category" do
+    setup [:create_essential_fixtures]
+
+    test "Edit Category form submission with correct data updates existing Category", %{
+      conn: conn,
+      book: book,
+      budget: budget
+    } do
+      category = category_fixture(%{name: "Existing Category", book_id: book.id})
+
+      {:ok, show_live, _html} = live(conn, ~p"/books/#{book}/budgets/#{budget.name}")
+
+      assert show_live |> element("#categories-#{category.id} a", "Edit") |> render_click() =~
+               "Edit Category"
+
+      assert_patch(
+        show_live,
+        ~p"/books/#{book}/budgets/#{budget.name}/categories/#{category}/edit"
+      )
+
+      {:ok, _show_live, html} =
+        show_live
+        |> form("#category-form", category: %{name: "Different Category"})
+        |> render_submit()
+        |> follow_redirect(conn, ~p"/books/#{book}/budgets/#{budget.name}")
+
+      assert html =~ "Category updated successfully"
+      assert html =~ "Different Category"
+      refute html =~ "Existing Category"
+    end
+
+    test "Edit Category form submission with blank data returns error", %{
+      conn: conn,
+      book: book,
+      budget: budget
+    } do
+      category = category_fixture(%{name: "Existing Category", book_id: book.id})
+
+      {:ok, show_live, _html} = live(conn, ~p"/books/#{book}/budgets/#{budget.name}")
+
+      assert show_live |> element("#categories-#{category.id} a", "Edit") |> render_click() =~
+               "Edit Category"
+
+      assert show_live
+             |> form("#category-form", category: %{name: ""})
+             |> render_change() =~ "is required"
+
+      assert show_live
+             |> form("#category-form", category: %{name: ""})
+             |> render_submit() =~ "is required"
+    end
+  end
+
+  describe "Delete Category" do
+    setup [:create_essential_fixtures]
+
+    test "Clicking Delete button removes Category from page", %{
+      conn: conn,
+      book: book,
+      budget: budget
+    } do
+      category = category_fixture(%{name: "Existing Category", book_id: book.id})
+
+      {:ok, show_live, _html} = live(conn, ~p"/books/#{book}/budgets/#{budget.name}")
+
+      assert show_live |> element("#categories-#{category.id} a", "Delete") |> render_click()
+
+      refute has_element?(show_live, "#categories-#{category.id}")
+    end
+
+    test "Delete button for Category vanishes from page when Category has existing Envelope records associated with it",
+         %{conn: conn, book: book, budget: budget} do
+      category = category_fixture(%{name: "Test Category", book_id: book.id})
+      envelope = envelope_fixture(%{name: "Test Envelope", category_id: category.id})
+
+      monthly_envelope_fixture(%{
+        budget_id: budget.id,
+        envelope_id: envelope.id,
+        assigned_cents: 1234
+      })
+
+      {:ok, show_live, html} = live(conn, ~p"/books/#{book}/budgets/#{budget.name}")
+
+      assert html =~ "Test Category"
+      assert html =~ "Test Envelope"
+      assert html =~ "12.34"
+      assert has_element?(show_live, "#categories-#{category.id} a", "Edit")
+      refute has_element?(show_live, "#categories-#{category.id} a.delete_category", "Delete")
+    end
+  end
+
+  defp create_essential_fixtures(_) do
+    book = book_fixture(name: "Test Book")
+
+    budget =
+      budget_fixture(%{
+        name: "202302",
+        month: ~D[2023-02-26],
+        book_id: book.id
+      })
+
+    category =
+      category_fixture(%{
+        name: "Test Category",
+        book_id: book.id
+      })
+
+    %{
+      book: book,
+      budget: budget,
+      category: category
+    }
+  end
+end

--- a/test/terrible_web/live/budget_live/envelope_test.exs
+++ b/test/terrible_web/live/budget_live/envelope_test.exs
@@ -1,0 +1,167 @@
+defmodule TerribleWeb.BudgetLive.EnvelopeTest do
+  use TerribleWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  describe "New Envelope" do
+    setup [:create_essential_fixtures]
+
+    test "New Envelope form submission with correct data creates a new Envelope", %{
+      conn: conn,
+      book: book,
+      budget: budget,
+      category: category
+    } do
+      {:ok, show_live, _html} = live(conn, ~p"/books/#{book}/budgets/#{budget.name}")
+
+      assert show_live |> element("a", "New Envelope") |> render_click() =~ "Create New Envelope"
+
+      assert_patch(
+        show_live,
+        ~p"/books/#{book}/budgets/#{budget.name}/categories/#{category}/envelopes/new"
+      )
+
+      {:ok, _show_live, html} =
+        show_live
+        |> form("#envelope-form", envelope: %{name: "Test New Envelope"})
+        |> render_submit()
+        |> follow_redirect(conn, ~p"/books/#{book}/budgets/#{budget.name}")
+
+      assert html =~ "Envelope created successfully"
+      assert html =~ "Test New Envelope"
+    end
+
+    test "New Envelope form submission with blank data returns error", %{
+      conn: conn,
+      book: book,
+      budget: budget
+    } do
+      {:ok, show_live, _html} = live(conn, ~p"/books/#{book}/budgets/#{budget.name}")
+
+      assert show_live |> element("a", "New Envelope") |> render_click() =~ "Create New Envelope"
+
+      assert show_live
+             |> form("#envelope-form", envelope: %{name: ""})
+             |> render_change() =~ "is required"
+
+      assert show_live
+             |> form("#envelope-form", envelope: %{name: ""})
+             |> render_submit() =~ "is required"
+    end
+  end
+
+  describe "Edit Envelope" do
+    setup [:create_essential_fixtures]
+
+    test "Edit Envelope form submission with correct data updates existing Envelope", %{
+      conn: conn,
+      book: book,
+      budget: budget,
+      category: category
+    } do
+      envelope = envelope_fixture(%{name: "Existing Envelope", category_id: category.id})
+
+      monthly_envelope_fixture(%{
+        budget_id: budget.id,
+        envelope_id: envelope.id,
+        assigned_cents: 1234
+      })
+
+      {:ok, show_live, _html} = live(conn, ~p"/books/#{book}/budgets/#{budget.name}")
+
+      assert show_live |> element("#envelopes-#{envelope.id} a", "Edit") |> render_click() =~
+               "Edit Envelope"
+
+      assert_patch(
+        show_live,
+        ~p"/books/#{book}/budgets/#{budget.name}/categories/#{category}/envelopes/#{envelope}/edit"
+      )
+
+      {:ok, _show_live, html} =
+        show_live
+        |> form("#envelope-form", envelope: %{name: "Different Envelope"})
+        |> render_submit()
+        |> follow_redirect(conn, ~p"/books/#{book}/budgets/#{budget.name}")
+
+      assert html =~ "Envelope updated successfully"
+      assert html =~ "Different Envelope"
+      refute html =~ "Existing Envelope"
+    end
+
+    test "Edit Envelope form submission with blank data returns error", %{
+      conn: conn,
+      book: book,
+      budget: budget,
+      category: category
+    } do
+      envelope = envelope_fixture(%{name: "Existing Envelope", category_id: category.id})
+
+      monthly_envelope_fixture(%{
+        budget_id: budget.id,
+        envelope_id: envelope.id,
+        assigned_cents: 1234
+      })
+
+      {:ok, show_live, _html} = live(conn, ~p"/books/#{book}/budgets/#{budget.name}")
+
+      assert show_live |> element("#envelopes-#{envelope.id} a", "Edit") |> render_click() =~
+               "Edit Envelope"
+
+      assert show_live
+             |> form("#envelope-form", envelope: %{name: ""})
+             |> render_change() =~ "is required"
+
+      assert show_live
+             |> form("#envelope-form", envelope: %{name: ""})
+             |> render_submit() =~ "is required"
+    end
+  end
+
+  describe "Delete Envelope" do
+    setup [:create_essential_fixtures]
+
+    test "Clicking Delete button removes Envelope from page", %{
+      conn: conn,
+      book: book,
+      budget: budget,
+      category: category
+    } do
+      envelope = envelope_fixture(%{name: "Existing Envelope", category_id: category.id})
+
+      monthly_envelope_fixture(%{
+        budget_id: budget.id,
+        envelope_id: envelope.id,
+        assigned_cents: 1234
+      })
+
+      {:ok, show_live, _html} = live(conn, ~p"/books/#{book}/budgets/#{budget.name}")
+
+      assert show_live |> element("#envelopes-#{envelope.id} a", "Delete") |> render_click()
+
+      refute has_element?(show_live, "#envelopes-#{envelope.id}")
+    end
+  end
+
+  defp create_essential_fixtures(_) do
+    book = book_fixture(name: "Test Book")
+
+    budget =
+      budget_fixture(%{
+        name: "202302",
+        month: ~D[2023-02-26],
+        book_id: book.id
+      })
+
+    category =
+      category_fixture(%{
+        name: "Test Category",
+        book_id: book.id
+      })
+
+    %{
+      book: book,
+      budget: budget,
+      category: category
+    }
+  end
+end

--- a/test/terrible_web/live/budget_live_test.exs
+++ b/test/terrible_web/live/budget_live_test.exs
@@ -2,9 +2,8 @@ defmodule TerribleWeb.BudgetLiveTest do
   use TerribleWeb.ConnCase
 
   import Phoenix.LiveViewTest
-  import Terrible.BudgetingFixtures
 
-  describe "Show - General" do
+  describe "Show" do
     setup [:create_all_fixtures]
 
     test "displays page", %{conn: conn, book: book, budget: budget, category: category} do
@@ -24,132 +23,6 @@ defmodule TerribleWeb.BudgetLiveTest do
       assert html =~ "12.34"
       assert html =~ "Test Envelope 2"
       assert html =~ "-43.21"
-    end
-  end
-
-  describe "Show - Categories" do
-    setup [:create_essential_fixtures]
-
-    test "New Category form submission with correct data creates a new Category", %{
-      conn: conn,
-      book: book,
-      budget: budget
-    } do
-      {:ok, show_live, _html} = live(conn, ~p"/books/#{book}/budgets/#{budget.name}")
-
-      assert show_live |> element("a", "New Category") |> render_click() =~ "Create New Category"
-
-      assert_patch(show_live, ~p"/books/#{book}/budgets/#{budget.name}/categories/new")
-
-      {:ok, _show_live, html} =
-        show_live
-        |> form("#category-form", category: %{name: "Test New Category"})
-        |> render_submit()
-        |> follow_redirect(conn, ~p"/books/#{book}/budgets/#{budget.name}")
-
-      assert html =~ "Category created successfully"
-      assert html =~ "Test New Category"
-    end
-
-    test "New Category form submission with blank data returns error", %{
-      conn: conn,
-      book: book,
-      budget: budget
-    } do
-      {:ok, show_live, _html} = live(conn, ~p"/books/#{book}/budgets/#{budget.name}")
-
-      assert show_live |> element("a", "New Category") |> render_click() =~ "Create New Category"
-
-      assert show_live
-             |> form("#category-form", category: %{name: ""})
-             |> render_change() =~ "is required"
-
-      assert show_live
-             |> form("#category-form", category: %{name: ""})
-             |> render_submit() =~ "is required"
-    end
-
-    test "Edit Category form submission with correct data updates existing Category", %{
-      conn: conn,
-      book: book,
-      budget: budget
-    } do
-      category = category_fixture(%{name: "Existing Category", book_id: book.id})
-
-      {:ok, show_live, _html} = live(conn, ~p"/books/#{book}/budgets/#{budget.name}")
-
-      assert show_live |> element("#categories-#{category.id} a", "Edit") |> render_click() =~
-               "Edit Category"
-
-      assert_patch(
-        show_live,
-        ~p"/books/#{book}/budgets/#{budget.name}/categories/#{category}/edit"
-      )
-
-      {:ok, _show_live, html} =
-        show_live
-        |> form("#category-form", category: %{name: "Different Category"})
-        |> render_submit()
-        |> follow_redirect(conn, ~p"/books/#{book}/budgets/#{budget.name}")
-
-      assert html =~ "Category updated successfully"
-      assert html =~ "Different Category"
-      refute html =~ "Existing Category"
-    end
-
-    test "Edit Category form submission with blank data returns error", %{
-      conn: conn,
-      book: book,
-      budget: budget
-    } do
-      category = category_fixture(%{name: "Existing Category", book_id: book.id})
-
-      {:ok, show_live, _html} = live(conn, ~p"/books/#{book}/budgets/#{budget.name}")
-
-      assert show_live |> element("#categories-#{category.id} a", "Edit") |> render_click() =~
-               "Edit Category"
-
-      assert show_live
-             |> form("#category-form", category: %{name: ""})
-             |> render_change() =~ "is required"
-
-      assert show_live
-             |> form("#category-form", category: %{name: ""})
-             |> render_submit() =~ "is required"
-    end
-
-    test "Clicking Delete button removes Category from page", %{
-      conn: conn,
-      book: book,
-      budget: budget
-    } do
-      category = category_fixture(%{name: "Existing Category", book_id: book.id})
-
-      {:ok, show_live, _html} = live(conn, ~p"/books/#{book}/budgets/#{budget.name}")
-
-      assert show_live |> element("#categories-#{category.id} a", "Delete") |> render_click()
-
-      refute has_element?(show_live, "#categories-#{category.id}")
-    end
-
-    test "Delete button for Category vanishes from page when Category has existing Envelope records associated with it",
-         %{conn: conn, book: book, budget: budget} do
-      category = category_fixture(%{name: "Test Category", book_id: book.id})
-      envelope = envelope_fixture(%{name: "Test Envelope", category_id: category.id})
-
-      monthly_envelope_fixture(%{
-        budget_id: budget.id,
-        envelope_id: envelope.id,
-        assigned_cents: 1234
-      })
-
-      {:ok, show_live, html} = live(conn, ~p"/books/#{book}/budgets/#{budget.name}")
-
-      assert html =~ "Test Category"
-      assert html =~ "Test Envelope"
-      assert html =~ "12.34"
-      assert has_element?(show_live, "#categories-#{category.id} a", "Edit")
-      refute has_element?(show_live, "#categories-#{category.id} a", "Delete")
     end
   end
 


### PR DESCRIPTION
This allows the user to create new Envelope records, edit, and delete existing ones.