### PR TITLE
Add Changelog description and change PR link order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
 ## [0.1.0] - 2023-03-10
 
 ### Added
@@ -16,19 +25,20 @@
 - Initial layout and improved design of Budgeting page. ([#15])
 - Use [AGPL-3.0](https://choosealicense.com/licenses/agpl-3.0/) as the license for this project. ([#17])
 
+[Unreleased]: https://github.com/terrible-hq/terrible/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/terrible-hq/terrible/releases/tag/v0.1.0
 
-[#1]: https://github.com/terrible-hq/terrible/pull/1
-[#2]: https://github.com/terrible-hq/terrible/pull/2
-[#3]: https://github.com/terrible-hq/terrible/pull/3
-[#4]: https://github.com/terrible-hq/terrible/pull/4
-[#6]: https://github.com/terrible-hq/terrible/pull/6
-[#8]: https://github.com/terrible-hq/terrible/pull/8
-[#9]: https://github.com/terrible-hq/terrible/pull/9
-[#10]: https://github.com/terrible-hq/terrible/pull/10
-[#11]: https://github.com/terrible-hq/terrible/pull/11
-[#12]: https://github.com/terrible-hq/terrible/pull/12
-[#13]: https://github.com/terrible-hq/terrible/pull/13
-[#14]: https://github.com/terrible-hq/terrible/pull/14
-[#15]: https://github.com/terrible-hq/terrible/pull/15
 [#17]: https://github.com/terrible-hq/terrible/pull/17
+[#15]: https://github.com/terrible-hq/terrible/pull/15
+[#14]: https://github.com/terrible-hq/terrible/pull/14
+[#13]: https://github.com/terrible-hq/terrible/pull/13
+[#12]: https://github.com/terrible-hq/terrible/pull/12
+[#11]: https://github.com/terrible-hq/terrible/pull/11
+[#10]: https://github.com/terrible-hq/terrible/pull/10
+[#9]: https://github.com/terrible-hq/terrible/pull/9
+[#8]: https://github.com/terrible-hq/terrible/pull/8
+[#6]: https://github.com/terrible-hq/terrible/pull/6
+[#4]: https://github.com/terrible-hq/terrible/pull/4
+[#3]: https://github.com/terrible-hq/terrible/pull/3
+[#2]: https://github.com/terrible-hq/terrible/pull/2
+[#1]: https://github.com/terrible-hq/terrible/pull/1


### PR DESCRIPTION
I forgot to add the intro/description for the Changelog file, so this adds that missing section.

This also changes the order of the PR links to have the latest PR at the top instead of bottom of the file.