### PR TITLE
Fix call to Ash notifiers in transactions

### DIFF
--- a/coveralls.json
+++ b/coveralls.json
@@ -5,6 +5,7 @@
     "lib/terrible/repo.ex",
     "lib/terrible_web.ex",
     "lib/terrible_web/controllers/authentication_controller.ex",
+    "lib/terrible_web/components/core_components.ex",
     "lib/terrible_web/components/layouts.ex",
     "lib/terrible_web/endpoint.ex",
     "lib/terrible_web/gettext.ex",

--- a/lib/terrible/budgeting/resources/book/changes/create_related_records.ex
+++ b/lib/terrible/budgeting/resources/book/changes/create_related_records.ex
@@ -64,11 +64,14 @@ defmodule Terrible.Budgeting.Book.Changes.CreateRelatedRecords do
   end
 
   defp create_book_owner(book_id, user_id) do
-    BookUser.create!(%{
-      book_id: book_id,
-      user_id: user_id,
-      role: :owner
-    })
+    BookUser.create!(
+      %{
+        book_id: book_id,
+        user_id: user_id,
+        role: :owner
+      },
+      return_notifications?: true
+    )
   end
 
   defp create_budgets(book_id) do
@@ -76,21 +79,27 @@ defmodule Terrible.Budgeting.Book.Changes.CreateRelatedRecords do
     next_month = current_month |> Date.end_of_month() |> Date.add(1)
 
     Enum.map([current_month, next_month], fn month ->
-      Budget.create!(%{
-        name: Utils.get_budget_name(month),
-        month: month,
-        book_id: book_id
-      })
+      Budget.create!(
+        %{
+          name: Utils.get_budget_name(month),
+          month: month,
+          book_id: book_id
+        },
+        return_notifications?: true
+      )
     end)
   end
 
   defp create_categories(book_id) do
     Enum.map(@list_of_categories_and_envelopes, fn content ->
-      Category.create!(%{
-        book_id: book_id,
-        name: content[:category],
-        envelopes: content[:envelopes]
-      })
+      Category.create!(
+        %{
+          book_id: book_id,
+          name: content[:category],
+          envelopes: content[:envelopes]
+        },
+        return_notifications?: true
+      )
     end)
   end
 end

--- a/lib/terrible/budgeting/resources/envelope/changes/create_monthly_envelopes.ex
+++ b/lib/terrible/budgeting/resources/envelope/changes/create_monthly_envelopes.ex
@@ -12,10 +12,13 @@ defmodule Terrible.Budgeting.Envelope.Changes.CreateMonthlyEnvelopes do
     Ash.Changeset.after_action(changeset, fn _, result ->
       with {:ok, envelope} <- Budgeting.load(result, category: [book: :budgets]) do
         Enum.each(envelope.category.book.budgets, fn budget ->
-          MonthlyEnvelope.create(%{
-            envelope_id: envelope.id,
-            budget_id: budget.id
-          })
+          MonthlyEnvelope.create(
+            %{
+              envelope_id: envelope.id,
+              budget_id: budget.id
+            },
+            return_notifications?: true
+          )
         end)
       end
 


### PR DESCRIPTION
Some of the create functions for the resources involve creating other records within a transaction.

Apparently, this will result in Ash notifiers being skipped, so we need to call them explicitly to play nice.

This also adds CoreComponents to the coverage ignore as we won't be touching this file at all. Only when Phoenix updates this module.