### PR TITLE
Revert "Improve UX of Accounts in BudgetLive#show"

### DIFF
--- a/lib/terrible_web/components/layouts.ex
+++ b/lib/terrible_web/components/layouts.ex
@@ -7,104 +7,51 @@ defmodule TerribleWeb.Layouts do
 
   embed_templates "layouts/*"
 
-  def sidebar_item_class(active) do
-    active_class =
-      if active do
-        "bg-indigo-700 text-white"
-      else
-        "text-indigo-200 hover:text-white hover:bg-indigo-700"
-      end
-
-    "#{active_class} group flex gap-x-3 rounded-md p-2 text-sm leading-6 font-semibold"
-  end
-
-  attr :account, :any, required: true
-  attr :book, :any, required: true
-  attr :budget, :any, required: true
-
-  def account_item(assigns) do
-    ~H"""
-    <li>
-      <div class={sidebar_item_class(false)}>
-        <div class="flex justify-center items-center">
-          <.link
-            patch={
-              ~p"/books/#{@book}/budgets/#{Utils.get_budget_name(Date.utc_today())}/accounts/#{@account}/edit"
-            }
-            class="edit-account"
-          >
-            <span class="sr-only">Edit Account - <%= @account.name %></span>
-            <span class="flex h-3 w-3 shrink-0 items-center justify-center font-medium text-indigo-600 hover:text-white">
-              <Heroicons.pencil mini />
-            </span>
-          </.link>
-          <.link
-            class="delete-account"
-            phx-click={
-              JS.push("delete_account", value: %{id: @account.id}) |> hide("#accounts-#{@account.id}")
-            }
-            data-confirm="Are you sure?"
-          >
-            <span class="sr-only">Delete Account - <%= @account.name %></span>
-            <span class="flex h-3 w-3 shrink-0 items-center justify-center font-medium text-indigo-600 hover:text-white">
-              <Heroicons.minus_circle mini />
-            </span>
-          </.link>
-        </div>
-        <.link navigate={~p"/books/#{@book}/budgets/#{@budget.name}"} aria-current="false">
-          <span class="sr-only">View Account - <%= @account.name %></span>
-          <span class="truncate"><%= @account.name %></span>
-        </.link>
-        <span class="justify-right flex-grow text-right">
-          $999,999.99
-        </span>
-      </div>
-    </li>
-    """
-  end
-
   def sidebar(assigns) do
     ~H"""
-    <div class="flex grow flex-col gap-y-5 overflow-y-auto bg-indigo-600 px-6 pb-2">
-      <div class="flex h-16 shrink-0 justify-center items-center">
-        <span class="text-white font-semibold"><%= @book.name %></span>
+    <div class="hidden lg:fixed lg:inset-y-0 lg:flex lg:w-64 lg:flex-col">
+      <div class="flex min-h-0 flex-1 flex-col border-r border-gray-200 bg-white">
+        <div class="flex flex-1 flex-col overflow-y-auto pt-5 pb-4">
+          <nav class="mt-5 flex-1 space-y-1 bg-white px-2">
+            <.link
+              navigate={~p"/books/#{@book}/budgets/#{Utils.get_budget_name(Date.utc_today())}"}
+              class={
+                "group flex items-center rounded-md px-2 py-2 text-sm font-medium #{if @active_nav_item == :budget, do: "bg-gray-100 text-gray-900", else: "text-gray-600 hover:bg-gray-50 hover:text-gray-900"}"
+              }
+              aria-current={if @active_nav_item == :budget, do: "true", else: "false"}
+            >
+              <Heroicons.inbox outline class="text-gray-500 mr-4 h-6 w-6 flex-shrink-0" /> Budget
+            </.link>
+          </nav>
+        </div>
+        <div>
+          <.link patch={
+            ~p"/books/#{@book}/budgets/#{Utils.get_budget_name(Date.utc_today())}/accounts/new"
+          }>
+            <.button>New Account</.button>
+          </.link>
+        </div>
+        <div id="account-list" phx-update="stream">
+          <div :for={{id, account} <- @accounts} id={id}>
+            <%= account.name %>
+            <.link
+              patch={
+                ~p"/books/#{@book}/budgets/#{Utils.get_budget_name(Date.utc_today())}/accounts/#{account}/edit"
+              }
+              class="text-indigo-600 hover:text-indigo-900"
+            >
+              Edit
+            </.link>
+            <.link
+              class="delete-account text-indigo-600 hover:text-indigo-900"
+              phx-click={JS.push("delete_account", value: %{id: account.id}) |> hide("##{id}")}
+              data-confirm="Are you sure?"
+            >
+              Delete
+            </.link>
+          </div>
+        </div>
       </div>
-      <nav class="flex flex-1 flex-col">
-        <ul role="list" class="flex flex-1 flex-col gap-y-7">
-          <li>
-            <ul role="list" class="-mx-2 space-y-1">
-              <li>
-                <.link
-                  navigate={~p"/books/#{@book}/budgets/#{Utils.get_budget_name(Date.utc_today())}"}
-                  class={sidebar_item_class(@active_nav_item == :budget)}
-                  aria-current={if @active_nav_item == :budget, do: "true", else: "false"}
-                >
-                  <Heroicons.inbox class="text-white h-6 w-6 flex-shrink-0" /> Budget
-                </.link>
-              </li>
-            </ul>
-          </li>
-          <li>
-            <div class="flex justify-between">
-              <div class="text-xs font-semibold leading-6 text-indigo-200">Your Accounts</div>
-              <div class="text-xs font-semibold leading-6 text-indigo-200 hover:text-white">
-                <.link patch={
-                  ~p"/books/#{@book}/budgets/#{Utils.get_budget_name(Date.utc_today())}/accounts/new"
-                }>
-                  Add Account
-                </.link>
-              </div>
-            </div>
-            <ul role="list" class="-mx-2 mt-2 space-y-1">
-              <div id="account-list" phx-update="stream">
-                <div :for={{id, account} <- @accounts} id={id}>
-                  <.account_item account={account} book={@book} budget={@budget} />
-                </div>
-              </div>
-            </ul>
-          </li>
-        </ul>
-      </nav>
     </div>
     """
   end

--- a/lib/terrible_web/components/layouts/book.html.heex
+++ b/lib/terrible_web/components/layouts/book.html.heex
@@ -1,72 +1,13 @@
-<div class="h-full">
-  <!-- Off-canvas menu for mobile, show/hide based on off-canvas menu state. -->
-  <div id="sidebar-mobile" class="relative z-50 lg:hidden" role="dialog" aria-modal="true">
-    <div class="fixed inset-0 bg-gray-900/80"></div>
-
-    <div class="fixed inset-0 flex">
-      <div class="relative mr-16 flex w-full max-w-xs flex-1">
-        <div class="absolute left-full top-0 flex w-16 justify-center pt-5">
-          <button type="button" class="-m-2.5 p-2.5">
-            <span class="sr-only">Close sidebar</span>
-            <svg
-              class="h-6 w-6 text-white"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke-width="1.5"
-              stroke="currentColor"
-              aria-hidden="true"
-            >
-              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
+<div class="h-full bg-gray-100">
+  <.sidebar active_nav_item={@active_nav_item} book={@book} accounts={@streams.accounts} />
+  <div class="flex flex-1 flex-col lg:pl-64 bg-white">
+    <main class="flex-1">
+      <div class="py-6">
+        <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <.flash_group flash={@flash} />
+          <%= @inner_content %>
         </div>
-        <.sidebar
-          active_nav_item={@active_nav_item}
-          book={@book}
-          budget={@budget}
-          accounts={@streams.accounts}
-        />
       </div>
-    </div>
+    </main>
   </div>
-  <!-- Static sidebar for desktop -->
-  <div
-    id="sidebar-desktop"
-    class="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-72 lg:flex-col"
-  >
-    <.sidebar
-      active_nav_item={@active_nav_item}
-      book={@book}
-      budget={@budget}
-      accounts={@streams.accounts}
-    />
-  </div>
-
-  <div class="sticky top-0 z-40 flex items-center gap-x-6 bg-indigo-600 px-4 py-4 shadow-sm sm:px-6 lg:hidden">
-    <button type="button" class="-m-2.5 p-2.5 text-indigo-200 lg:hidden">
-      <span class="sr-only">Open Sidebar</span>
-      <svg
-        class="h-6 w-6"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke-width="1.5"
-        stroke="currentColor"
-        aria-hidden="true"
-      >
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
-        />
-      </svg>
-    </button>
-    <div class="flex-1 text-sm font-semibold leading-6 text-white">Current Page Title</div>
-  </div>
-
-  <main class="py-10 lg:pl-72">
-    <div class="px-4 sm:px-6 lg:px-8">
-      <.flash_group flash={@flash} />
-      <%= @inner_content %>
-    </div>
-  </main>
 </div>

--- a/lib/terrible_web/components/layouts/root.html.heex
+++ b/lib/terrible_web/components/layouts/root.html.heex
@@ -11,7 +11,7 @@
     <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}>
     </script>
   </head>
-  <body class="antialiased h-full bg-white">
+  <body class="bg-white antialiased">
     <%= @inner_content %>
   </body>
 </html>

--- a/test/terrible_web/live/budget_live/account_test.exs
+++ b/test/terrible_web/live/budget_live/account_test.exs
@@ -28,8 +28,7 @@ defmodule TerribleWeb.BudgetLive.AccountTest do
     } do
       {:ok, show_live, _html} = live(conn, ~p"/books/#{book}/budgets/#{budget.name}")
 
-      assert show_live |> element("#sidebar-desktop a", "Add Account") |> render_click() =~
-               "Create New Account"
+      assert show_live |> element("a", "New Account") |> render_click() =~ "Create New Account"
 
       assert_patch(show_live, ~p"/books/#{book}/budgets/#{budget.name}/accounts/new")
 
@@ -53,8 +52,7 @@ defmodule TerribleWeb.BudgetLive.AccountTest do
     } do
       {:ok, show_live, _html} = live(conn, ~p"/books/#{book}/budgets/#{budget.name}")
 
-      assert show_live |> element("#sidebar-desktop a", "Add Account") |> render_click() =~
-               "Create New Account"
+      assert show_live |> element("a", "New Account") |> render_click() =~ "Create New Account"
 
       assert show_live
              |> form("#account-form", account: %{name: ""})
@@ -94,12 +92,7 @@ defmodule TerribleWeb.BudgetLive.AccountTest do
 
       {:ok, show_live, _html} = live(conn, ~p"/books/#{book}/budgets/#{budget.name}")
 
-      assert show_live
-             |> element(
-               "#sidebar-desktop #accounts-#{account.id} a",
-               "Edit Account - #{account.name}"
-             )
-             |> render_click() =~
+      assert show_live |> element("#accounts-#{account.id} a", "Edit") |> render_click() =~
                "Edit Account"
 
       assert_patch(
@@ -134,9 +127,7 @@ defmodule TerribleWeb.BudgetLive.AccountTest do
 
       {:ok, show_live, _html} = live(conn, ~p"/books/#{book}/budgets/#{budget.name}")
 
-      assert show_live
-             |> element("#sidebar-desktop #accounts-#{account.id} a", "Edit")
-             |> render_click() =~
+      assert show_live |> element("#accounts-#{account.id} a", "Edit") |> render_click() =~
                "Edit Account"
 
       assert show_live
@@ -177,9 +168,7 @@ defmodule TerribleWeb.BudgetLive.AccountTest do
 
       {:ok, show_live, _html} = live(conn, ~p"/books/#{book}/budgets/#{budget.name}")
 
-      assert show_live
-             |> element("#sidebar-desktop #accounts-#{account.id} a", "Delete")
-             |> render_click()
+      assert show_live |> element("#accounts-#{account.id} a", "Delete") |> render_click()
 
       refute has_element?(show_live, "#accounts-#{account.id}")
     end


### PR DESCRIPTION
Reverts terrible-hq/terrible#32

There is a bug where the accounts list keeps getting appended to the screen instead of just replacing the existing elements. I've tried so hard to solve it to no avail. I'll just try a different approach.